### PR TITLE
Fix: Relase action permission #1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,16 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # https://docs.github.com/ko/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -25,6 +32,8 @@ jobs:
         with:
           commit: "Chore: Version Packages"
           publish: npm run publish
+          setupGitUser: true
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Error log:
```
Run changesets/action@v1
setting git user
/usr/bin/git config user.name "github-actions[bot]"
/usr/bin/git config user.email "github-actions[bot]@users.noreply.github.com"
setting GitHub credentials
/usr/bin/git checkout changeset-release/master
error: pathspec 'changeset-release/master' did not match any file(s) known to git
/usr/bin/git checkout -b changeset-release/master
Switched to a new branch 'changeset-release/master'
/usr/bin/git reset --hard e5894cdf844a7b3b20a1ff8aafd8e31dcac9a252
HEAD is now at e5894cd Fix: Remove blank of config #1
/usr/local/bin/node /home/runner/work/csstype/csstype/node_modules/@changesets/cli/bin.js version
🦋  All files have been updated. Review them and commit at your leisure
/usr/bin/git status --porcelain
 D .changeset/honest-bees-kiss.md
 M package.json
?? CHANGELOG.md
/usr/bin/git add .
/usr/bin/git commit -m Chore: Version Packages
[changeset-release/master 43fe6c1] Chore: Version Packages
 3 files changed, 9 insertions(+), 7 deletions(-)
 delete mode 100644 .changeset/honest-bees-kiss.md
 create mode 100644 CHANGELOG.md
/usr/bin/git push origin HEAD:changeset-release/master --force
remote: Permission to mincho-js/csstype.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/mincho-js/csstype/': The requested URL returned error: 403
```